### PR TITLE
Skip over parsing errors for line number

### DIFF
--- a/core/src/com/sonyericsson/chkbugreport/plugins/stacktrace/StackTraceScanner.java
+++ b/core/src/com/sonyericsson/chkbugreport/plugins/stacktrace/StackTraceScanner.java
@@ -140,7 +140,11 @@ import java.util.regex.Pattern;
                                     int position = lineS.lastIndexOf(':');
                                     lineS = lineS.substring(position+1);
                                 }
-                                line = Integer.parseInt(lineS);
+                                try {
+                                  line = Integer.parseInt(lineS);
+                                } catch(NumberFormatException e) {
+                                  br.printErr(4, "Skipping parsing for misformed line number: " + lineS);
+                                }
                             }
                             StackTraceItem item = new StackTraceItem(method, fileName, line);
                             curStackTrace.addStackTraceItem(item);


### PR DESCRIPTION
Skip over missing line numbers, not all stack traces have correct line numbers:

```
"highpool[0]" prio=5 tid=21 Waiting
  | group="main" sCount=1 dsCount=0 flags=1 obj=0x12f00848 self=0x70daf59000
  | sysTid=2094 nice=9 cgrp=default sched=0/0 handle=0x7073bc4d50
  | state=S schedstat=( 2427913 393338 14 ) utm=0 stm=0 core=4 HZ=100
  | stack=0x7073ac2000-0x7073ac4000 stackSize=1039KB
  | held mutexes=
  at sun.misc.Unsafe.park(Native method)
  - waiting on an unknown object
  at java.util.concurrent.locks.LockSupport.park(LockSupport.java:190)
  at java.util.concurrent.SynchronousQueue$TransferStack.awaitFulfill(SynchronousQueue.java:459)
  at java.util.concurrent.SynchronousQueue$TransferStack.transfer(SynchronousQueue.java:362)
  at java.util.concurrent.SynchronousQueue.take(SynchronousQueue.java:920)
  at java.util.concurrent.ThreadPoolExecutor.getTask(ThreadPoolExecutor.java:1092)
  at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1152)
  at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:641)
  at tcn.run(:com.google.android.gms@19629037@19.6.29 (120400-278422107):-1)
  at java.lang.Thread.run(Thread.java:919)
```

This PR does not actually attempt to parse these lines, it just prints that it's skipping over them in the parsing log.